### PR TITLE
Make consensus fault probability configurable

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -25,6 +25,7 @@ blockchain:
   consensus: "PBFT"
   num_nodes: 5
   fault_tolerance: 1
+  fault_probability: 0.05
 
 logging:
   output_dir: "logs/"

--- a/examples/attack_scenario_sybil.py
+++ b/examples/attack_scenario_sybil.py
@@ -44,7 +44,8 @@ class Agent:
         self.consensus = ConsensusEngine(
             mechanism=config['blockchain']['consensus'],
             num_nodes=config['blockchain']['num_nodes'],
-            fault_tolerance=config['blockchain']['fault_tolerance']
+            fault_tolerance=config['blockchain']['fault_tolerance'],
+            fault_probability=config['blockchain']['fault_probability']
         )
         self.malicious = False
 

--- a/examples/minimal_chainfl_run.py
+++ b/examples/minimal_chainfl_run.py
@@ -20,7 +20,8 @@ class Agent:
         self.consensus = ConsensusEngine(
             mechanism=config['blockchain']['consensus'],
             num_nodes=config['blockchain']['num_nodes'],
-            fault_tolerance=config['blockchain']['fault_tolerance']
+            fault_tolerance=config['blockchain']['fault_tolerance'],
+            fault_probability=config['blockchain']['fault_probability']
         )
 
     def _generate_data(self):

--- a/src/chainfl/blockchain/consensus.py
+++ b/src/chainfl/blockchain/consensus.py
@@ -2,15 +2,23 @@ import random
 import time
 
 class ConsensusEngine:
-    def __init__(self, mechanism="PBFT", num_nodes=5, fault_tolerance=1):
+    def __init__(
+        self,
+        mechanism="PBFT",
+        num_nodes=5,
+        fault_tolerance=1,
+        fault_probability=0.0,
+    ):
         """
         :param mechanism: consensus algorithm (currently only PBFT simulated)
         :param num_nodes: number of simulated validators
         :param fault_tolerance: max number of faulty nodes allowed
+        :param fault_probability: probability that a node behaves faultily
         """
         self.mechanism = mechanism
         self.num_nodes = num_nodes
         self.fault_tolerance = fault_tolerance
+        self.fault_probability = fault_probability
         self.quorum = self.num_nodes - self.fault_tolerance
 
     def validate_block(self, block_data: dict) -> bool:
@@ -22,7 +30,7 @@ class ConsensusEngine:
 
         for i in range(self.num_nodes):
             # Optional logic for faulty node behavior
-            if random.random() < 0.05:  # 5% chance node fails
+            if random.random() < self.fault_probability:
                 votes.append(False)
             else:
                 votes.append(self.simulate_node_validation(block_data))

--- a/tests/test_consensus.py
+++ b/tests/test_consensus.py
@@ -1,6 +1,16 @@
+import random
+
 from chainfl.blockchain import ConsensusEngine
 
 def test_consensus_approves_valid_block():
+    random.seed(57)
     engine = ConsensusEngine()
     block_data = {"model_hash": "abc", "agent_id": "x", "signature": "sig"}
     assert engine.validate_block(block_data) is True
+
+
+def test_consensus_with_fault_probability_can_reject_block():
+    random.seed(57)
+    engine = ConsensusEngine(fault_probability=0.05)
+    block_data = {"model_hash": "abc", "agent_id": "x", "signature": "sig"}
+    assert engine.validate_block(block_data) is False


### PR DESCRIPTION
## Summary
- allow configuring the consensus engine's simulated fault probability and default it to zero
- extend consensus tests to cover deterministic and fault-injected behavior
- update config and examples to explicitly set non-zero fault probabilities when needed
