### PR TITLE
Ensure round robin scheduler wraps selection

### DIFF
--- a/src/chainfl/simulator/scheduler.py
+++ b/src/chainfl/simulator/scheduler.py
@@ -39,7 +39,7 @@ class Scheduler:
         elif self.mode == "round_robin":
             k = max(1, int(len(agents) * self.sample_ratio))
             start = (current_round * k) % len(agents)
-            return agents[start:start + k]
+            return [agents[(start + offset) % len(agents)] for offset in range(k)]
 
         else:
             raise ValueError(f"Unknown scheduling mode: {self.mode}")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,33 @@
+import pytest
+
+from chainfl.simulator.scheduler import Scheduler
+
+
+def make_agents(count):
+    return [f"agent_{idx}" for idx in range(count)]
+
+
+@pytest.mark.parametrize(
+    "sample_ratio, expected_first_round",
+    [
+        (0.4, ["agent_0", "agent_1"]),
+        (0.6, ["agent_0", "agent_1", "agent_2"]),
+    ],
+)
+def test_round_robin_selection_wraps_and_preserves_size(sample_ratio, expected_first_round):
+    agents = make_agents(5)
+    scheduler = Scheduler(mode="round_robin", sample_ratio=sample_ratio)
+    k = len(expected_first_round)
+
+    selections = [scheduler.select_agents(agents, round_idx) for round_idx in range(5)]
+
+    # First round should match expected baseline selection
+    assert selections[0] == expected_first_round
+
+    # Every round must select exactly k agents
+    assert all(len(selection) == k for selection in selections)
+
+    # Verify wrap-around occurs when advancing far enough
+    wrap_round = len(agents) // k + 1
+    expected_wrap = [agents[(wrap_round * k + offset) % len(agents)] for offset in range(k)]
+    assert selections[wrap_round] == expected_wrap


### PR DESCRIPTION
## Summary
- ensure the round robin scheduler always returns k agents by wrapping indices
- add scheduler tests that confirm wrap-around behavior and constant selection sizes

